### PR TITLE
fix: indexの置換処理を改善し、正規表現を使用してインデックスを動的に扱う

### DIFF
--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -42,7 +42,7 @@ ${stackLine}`);
   }
 };
 
-// src/stamper.ts
+// src/Stamper.ts
 var Stamper = class {
   rootEl;
   tempEl;
@@ -136,14 +136,27 @@ var Stamper = class {
         `${DIRECTIVE_VALUES.index}`
       );
       if (targetAttrKeys) {
-        const targetAttrKeysArray = targetAttrKeys.split(",");
-        targetAttrKeysArray.forEach((targetAttrKey) => {
-          const targetAttrValue = indexEl.getAttribute(targetAttrKey)?.replace(/{{index}}/gi, this.currentIndex.toString()).replace(
-            /{{index\+\+}}/gi,
-            (this.currentIndex + 1).toString()
-          );
+        const indexMarkerRegExp = new RegExp(
+          `{{${this.identifier}:index}}`,
+          "gi"
+        );
+        const incrementedIndexMarkerRegExp = new RegExp(
+          `{{${this.identifier}:index\\+\\+}}`,
+          "gi"
+        );
+        targetAttrKeys.split(",").forEach((targetAttrKey) => {
+          const targetAttrValue = indexEl.getAttribute(targetAttrKey);
           if (targetAttrValue) {
-            indexEl.setAttribute(targetAttrKey, targetAttrValue);
+            let replacedValue;
+            replacedValue = targetAttrValue.replace(
+              indexMarkerRegExp,
+              this.currentIndex.toString()
+            );
+            replacedValue = replacedValue.replace(
+              incrementedIndexMarkerRegExp,
+              (this.currentIndex + 1).toString()
+            );
+            indexEl.setAttribute(targetAttrKey, replacedValue);
           }
         });
       }

--- a/dist/mock/index.html
+++ b/dist/mock/index.html
@@ -22,7 +22,13 @@
       <template s-temp="mock">
         <div class="">
           <div s-sequence="0">連番</div>
-          <div name="{{index}}" s-index="name">タイトル</div>
+          <div
+            name="{{mock:index}}"
+            inc="{{mock:index++}}"
+            s-index="name,inc"
+          >
+            タイトル
+          </div>
           <button
             type="button"
             s-delete="mock"

--- a/src/Stamper.ts
+++ b/src/Stamper.ts
@@ -105,18 +105,37 @@ class Stamper {
       const targetAttrKeys = indexEl.getAttribute(
         `${DIRECTIVE_VALUES.index}`,
       );
+
       if (targetAttrKeys) {
-        const targetAttrKeysArray = targetAttrKeys.split(",");
-        targetAttrKeysArray.forEach((targetAttrKey) => {
-          const targetAttrValue = indexEl
-            .getAttribute(targetAttrKey)
-            ?.replace(/{{index}}/gi, this.currentIndex.toString())
-            .replace(
-              /{{index\+\+}}/gi,
+        // indexの置換用正規表現
+        const indexMarkerRegExp = new RegExp(
+          `{{${this.identifier}:index}}`,
+          "gi",
+        );
+        // index++の置換用正規表現
+        const incrementedIndexMarkerRegExp = new RegExp(
+          `{{${this.identifier}:index\\+\\+}}`,
+          "gi",
+        );
+
+        targetAttrKeys.split(",").forEach((targetAttrKey) => {
+          const targetAttrValue = indexEl.getAttribute(targetAttrKey);
+
+          if (targetAttrValue) {
+            let replacedValue;
+
+            // {{identifier:index}}をインデックスに置換
+            replacedValue = targetAttrValue.replace(
+              indexMarkerRegExp,
+              this.currentIndex.toString(),
+            );
+
+            // {{identifier:index++}}をインクリメントされたインデックスに置換
+            replacedValue = replacedValue.replace(
+              incrementedIndexMarkerRegExp,
               (this.currentIndex + 1).toString(),
             );
-          if (targetAttrValue) {
-            indexEl.setAttribute(targetAttrKey, targetAttrValue);
+            indexEl.setAttribute(targetAttrKey, replacedValue);
           }
         });
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { Stamper } from "~/stamper";
+export { Stamper } from "~/Stamper";

--- a/src/stamper.spec.ts
+++ b/src/stamper.spec.ts
@@ -10,7 +10,7 @@ import {
   test,
   vi,
 } from "vitest";
-import { Stamper } from "~/stamper";
+import { Stamper } from "~/Stamper";
 
 // 定数定義
 const HTML_FILEPATH = path.resolve(
@@ -155,14 +155,13 @@ describe("Stamperの動作テスト", () => {
     const stamper = new Stamper({ rootEl });
     stamper.init();
     let indexEls: NodeListOf<HTMLElement>;
-    const modifier = "name";
 
     addBtn.click();
 
     Array.from(crateEl.children).forEach((child, index) => {
-      const indexEls = child.querySelectorAll(`[s-index=${modifier}]`);
+      const indexEls = child.querySelectorAll(`[s-index]`);
       indexEls.forEach((indexEl) => {
-        expect(indexEl.getAttribute(modifier)).toBe(index.toString());
+        expect(indexEl.getAttribute("name")).toBe(index.toString());
       });
     });
   });


### PR DESCRIPTION
このプル リクエストには、機能を強化し、問題を修正するために、`Stamper` クラスとその関連ファイルに対するいくつかの変更が含まれています。最も重要な変更には、インデックス置換ロジックの変更、インポート パスの修正、およびこれらの変更を反映するためのテストの更新が含まれます。

### `Stamper` クラスの機能強化:

* [`src/Stamper.ts`](diffhunk://#diff-dfc3a72aeb89605c5f380ffba1bf8f2caf43806a96875cf0b091bc04bd86690aR108-R138): インデックスと増分インデックス マーカーの正規表現を導入することでインデックス置換ロジックを改善し、属性置換プロセスを更新しました。これらの正規表現を使用するには。

### インポートパスの修正:

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L1-R1): 正しい大文字と小文字を使用するように `Stamper` のインポート パスを修正しました。
* [`src/stamper.spec.ts`](diffhunk://#diff-ec042214c1ac302a71aa83032a8e6509b1647c1ebecd158db0da1008ea41fe79L13-R13): 正しい大文字と小文字を使用するように `Stamper` のインポート パスを更新しました。

### テストの更新:

* [`src/stamper.spec.ts`](diffhunk://#diff-ec042214c1ac302a71aa83032a8e6509b1647c1ebecd158db0da1008ea41fe79L158-R164): 正しい属性セレクターと期待値を使用するようにテストを変更し、テストが更新されたものと一致するようにしました。 「Stamper」クラスのロジック。